### PR TITLE
Fix pyminifier on Python 2.6 by always checking that sys.version_info is not a tuple

### DIFF
--- a/pyminifier/__init__.py
+++ b/pyminifier/__init__.py
@@ -78,12 +78,13 @@ from . import compression
 
 py3 = False
 lzma = False
-if sys.version_info.major == 3:
-    py3 = True
-    try:
-        import lzma
-    except ImportError:
-        pass
+if not isinstance(sys.version_info, tuple):
+    if sys.version_info.major == 3:
+        py3 = True
+        try:
+            import lzma
+        except ImportError:
+            pass
 
 # Regexes
 multiline_indicator = re.compile('\\\\(\s*#.*)?\n')

--- a/pyminifier/__main__.py
+++ b/pyminifier/__main__.py
@@ -6,12 +6,13 @@ from . import __version__
 
 py3 = False
 lzma = False
-if sys.version_info.major == 3:
-    py3 = True
-    try:
-        import lzma
-    except ImportError:
-        pass
+if not isinstance(sys.version_info, tuple):
+    if sys.version_info.major == 3:
+        py3 = True
+        try:
+            import lzma
+        except ImportError:
+            pass
 
 def main():
     """

--- a/pyminifier/analyze.py
+++ b/pyminifier/analyze.py
@@ -14,7 +14,7 @@ except ImportError: # Ahh, Python 3
 # Globals
 py3 = False
 
-if not isinstance(sys.version_info.major, tuple):
+if not isinstance(sys.version_info, tuple):
     if sys.version_info.major == 3:
         py3 = True
 

--- a/pyminifier/compression.py
+++ b/pyminifier/compression.py
@@ -44,8 +44,9 @@ import os, sys, tempfile, shutil
 from . import analyze, token_utils, minification, obfuscate
 
 py3 = False
-if sys.version_info.major == 3:
-    py3 = True
+if not isinstance(sys.version_info, tuple):
+    if sys.version_info.major == 3:
+        py3 = True
 
 def bz2_pack(source):
     """

--- a/pyminifier/obfuscate.py
+++ b/pyminifier/obfuscate.py
@@ -13,8 +13,9 @@ from itertools import permutations
 from . import analyze
 from . import token_utils
 
-if sys.version_info.major == 3:
-    unichr = chr # So we can support both 2 and 3
+if not isinstance(sys.version_info, tuple):
+    if sys.version_info.major == 3:
+        unichr = chr # So we can support both 2 and 3
 
 try:
     unichr(0x10000) # Will throw a ValueError on narrow Python builds


### PR DESCRIPTION
In Python 2.6, `sys.version_info` is a tuple. Version 2.7 changed it to a named tuple that has the `.major` key. However, checking for `.major` breaks compatibility with 2.6.

This PR adds checks to verify that `sys.version_info` is indeed *not* a tuple before checking its `.major` attribute. If it's a tuple, it's guaranteed to be <3. This is the same check that got added in [this commit](https://github.com/liftoff/pyminifier/commit/6e3109c0dd5e2865d3af130c26007d7d3ea0f744).

