### PR TITLE
Bugfix - Add module if not yet in module list

### DIFF
--- a/pyminifier/analyze.py
+++ b/pyminifier/analyze.py
@@ -413,7 +413,7 @@ def enumerate_local_modules(tokens, path):
                     module = "%s.%s" % (module_tree, f)
                 else:
                     module = f
-                if module in modules:
+                if not module in modules:
                     local_modules.append(module)
     return local_modules
 


### PR DESCRIPTION
A missing "not" in the if clause causes that modules are added if already in list. (not possible)