### PR TITLE
fix a ZeroDivisonError when cumulative_size is zero

### DIFF
--- a/pyminifier/__init__.py
+++ b/pyminifier/__init__.py
@@ -267,8 +267,11 @@ def pyminify(options, files):
             print((
                 "{sourcefile} ({filesize}) reduced to {new_filesize} bytes "
                 "({percent_saved}% of original size)").format(**locals()))
-        p_saved = round(
-            (float(cumulative_new) / float(cumulative_size) * 100), 2)
+        if cumulative_size:
+            p_saved = round(
+                (float(cumulative_new) / float(cumulative_size) * 100), 2)
+        else:
+            p_saved = 0
         print("Overall size reduction: {0}% of original size".format(p_saved))
     else:
         # Get the module name from the path


### PR DESCRIPTION
If the cumulative size is 0, the program will crash with `ZeroDivisionError`

The PR should fix that.

```
afg@sceptile ~/p/pyminifier (master)> 
python -m pyminifier __init__.py empty.py 
__init__.py (0) reduced to 64 bytes (0% of original size)
empty.py (0) reduced to 64 bytes (0% of original size)
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/afg/projects/pyminifier/pyminifier/__main__.py", line 175, in <module>
    main()
  File "/home/afg/projects/pyminifier/pyminifier/__main__.py", line 171, in main
    pyminify(options, files)
  File "/home/afg/projects/pyminifier/pyminifier/__init__.py", line 271, in pyminify
    (float(cumulative_new) / float(cumulative_size) * 100), 2)
ZeroDivisionError: float division by zero
```