### PR TITLE
Drop python2 support and fix setup.py install

### DIFF
--- a/pyminifier/__init__.py
+++ b/pyminifier/__init__.py
@@ -68,7 +68,7 @@ something is broken.
 # Import built-in modules
 import os, sys, re, io
 from optparse import OptionParser
-from collections import Iterable
+from collections.abc import Iterable
 
 # Import our own modules
 from . import minification

--- a/pyminifier/analyze.py
+++ b/pyminifier/analyze.py
@@ -6,10 +6,7 @@ A module of useful functions for analyzing Python code.
 
 # Import builtins
 import os, sys, re, tokenize, keyword
-try:
-    import cStringIO as io
-except ImportError: # Ahh, Python 3
-    import io
+import io
 
 # Globals
 py3 = False

--- a/pyminifier/minification.py
+++ b/pyminifier/minification.py
@@ -6,10 +6,7 @@ Module for minification functions.
 
 # Import built-in modules
 import re, tokenize, keyword
-try:
-    import cStringIO as io
-except ImportError: # We're using Python 3
-    import io
+import io
 
 # Import our own modules
 from . import analyze, token_utils

--- a/pyminifier/obfuscate.py
+++ b/pyminifier/obfuscate.py
@@ -13,12 +13,9 @@ from itertools import permutations
 from . import analyze
 from . import token_utils
 
-if not isinstance(sys.version_info, tuple):
-    if sys.version_info.major == 3:
-        unichr = chr # So we can support both 2 and 3
 
 try:
-    unichr(0x10000) # Will throw a ValueError on narrow Python builds
+    chr(0x10000) # Will throw a ValueError on narrow Python builds
     HIGHEST_UNICODE = 0x10FFFF # 1114111
 except:
     HIGHEST_UNICODE = 0xFFFF # 65535

--- a/pyminifier/token_utils.py
+++ b/pyminifier/token_utils.py
@@ -6,10 +6,7 @@ module.
 """
 
 import tokenize
-try:
-    import cStringIO as io
-except ImportError: # We're using Python 3
-    import io
+import io
 
 def untokenize(tokens):
     """

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 import sys
 import pyminifier
 from setuptools import setup
-from distutils.command.install import INSTALL_SCHEMES
-from distutils.command.build_py import build_py
-
-for scheme in INSTALL_SCHEMES.values():
-    scheme['data'] = scheme['purelib']
-
-extra = {}
 
 if isinstance(sys.version_info, tuple):
     major = sys.version_info[0]
@@ -18,14 +11,11 @@ if major == 2:
     print("Python 2 is no longer supported.")
     sys.exit(1)
 
-cmdclass = {'build_py': build_py}
-
 setup(
     name="pyminifier",
     version=pyminifier.__version__,
     description="Python code minifier, obfuscator, and compressor",
     author=pyminifier.__author__,
-    cmdclass=cmdclass,
     author_email="daniel.mcdougall@liftoffsoftware.com",
     url="https://github.com/liftoff/pyminifier",
     license="Proprietary",
@@ -54,5 +44,4 @@ setup(
         ],
     },
     test_suite = "tests",
-    **extra
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import sys
 import pyminifier
 from setuptools import setup
 from distutils.command.install import INSTALL_SCHEMES
+from distutils.command.build_py import build_py
 
 for scheme in INSTALL_SCHEMES.values():
     scheme['data'] = scheme['purelib']
@@ -14,18 +15,8 @@ else:
     major = sys.version_info.major
 
 if major == 2:
-    from distutils.command.build_py import build_py
-elif major == 3:
-    extra['use_2to3'] = True # Automatically convert to Python 3; love it!
-    try:
-        from distutils.command.build_py import build_py_2to3 as build_py
-    except ImportError:
-        print("Python 3.X support requires the 2to3 tool.")
-        print(
-            "It normally comes with Python 3.X but (apparenty) not on your "
-            "distribution.\nPlease find out what package you need to get 2to3"
-            "and install it.")
-        sys.exit(1)
+    print("Python 2 is no longer supported.")
+    sys.exit(1)
 
 cmdclass = {'build_py': build_py}
 


### PR DESCRIPTION
This PR proposes dropping Python 2 support to fix problems with setup.py. It also drops use of distutils as it is slated for removal in Python 3.12. The changes are minimal and do not break the tests (neither the repo tests, nor manual tests I performed myself with data on my own use of pyminifier).